### PR TITLE
Update server.go

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -31,7 +31,7 @@ func main() {
 		// Ensure that we only use our "CA" to validate certificates
 		ClientCAs: clientCertPool,
 		// PFS because we can
-		CipherSuites: []uint16{tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384},
+		CipherSuites: []uint16{tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256},
 		// Force it server side
 		PreferServerCipherSuites: true,
 		// TLS 1.2 because we can


### PR DESCRIPTION
````
2020/01/01 05:25:30 http2: TLSConfig.CipherSuites is missing an HTTP/2-required AES_128_GCM_SHA256 cipher.
````